### PR TITLE
Add cSCPIDelegate from com5003d / mt310s2d / sec1000d

### DIFF
--- a/src/scpi-tcp/CMakeLists.txt
+++ b/src/scpi-tcp/CMakeLists.txt
@@ -12,8 +12,9 @@ add_library(scpi-tcp SHARED
     )
 
 target_link_libraries(scpi-tcp
-    PRIVATE
+    PUBLIC
     Qt5::Core
+    SCPI
     VeinMeta::xiqnet 
     )
 

--- a/src/scpi-tcp/scpidelegate.cpp
+++ b/src/scpi-tcp/scpidelegate.cpp
@@ -1,0 +1,36 @@
+#include <QStringList>
+#include <scpi.h>
+#include <scpiobject.h>
+#include <QDebug>
+
+#include "scpidelegate.h"
+
+
+cSCPIDelegate::cSCPIDelegate(QString cmdParent, QString cmd, quint8 type, cSCPI *scpiInterface, quint16 cmdCode)
+    :cSCPIObject(cmd, type), m_nCmdCode(cmdCode)
+{
+    m_sCommand = QString("%1:%2").arg(cmdParent).arg(cmd);
+    scpiInterface->genSCPICmd(cmdParent.split(":"), this);
+}
+
+
+bool cSCPIDelegate::executeSCPI(const QString &sInput, QString &sOutput)
+{
+    emit execute(m_nCmdCode,(QString&) sInput, sOutput);
+    return true;
+}
+
+
+bool cSCPIDelegate::executeSCPI(cProtonetCommand *protoCmd)
+{
+    emit execute(m_nCmdCode, protoCmd);
+    return true;
+}
+
+
+QString cSCPIDelegate::getCommand()
+{
+    return m_sCommand;
+}
+
+

--- a/src/scpi-tcp/scpidelegate.h
+++ b/src/scpi-tcp/scpidelegate.h
@@ -1,0 +1,32 @@
+#ifndef SCPIDELEGATE_H
+#define SCPIDELEGATE_H
+
+#include <QObject>
+#include <QString>
+
+#include "scpiobject.h"
+
+class cSCPI;
+class cProtonetCommand;
+
+class cSCPIDelegate: public QObject, public cSCPIObject
+{
+   Q_OBJECT
+
+public:
+    cSCPIDelegate(QString cmdParent, QString cmd, quint8 type, cSCPI *scpiInterface, quint16 cmdCode);
+    virtual bool executeSCPI(const QString& sInput, QString& sOutput);
+    virtual bool executeSCPI(cProtonetCommand* protoCmd);
+    QString getCommand();
+
+signals:
+    void execute(int cmdCode, QString& sInput, QString& sOutput);
+    void execute(int cmdCode, cProtonetCommand* protoCmd);
+
+private:
+    quint16 m_nCmdCode;
+    QString m_sCommand;
+};
+
+
+#endif // SCPIDELEGATE_H

--- a/src/scpi/CMakeLists.txt
+++ b/src/scpi/CMakeLists.txt
@@ -13,7 +13,7 @@ add_library(SCPI SHARED
     )
 
 target_link_libraries(SCPI
-    PRIVATE
+    PUBLIC
     Qt5::Core
     Qt5::Xml
     Qt5::Gui
@@ -22,10 +22,9 @@ target_link_libraries(SCPI
 # announce headers - target perspective
 target_include_directories(SCPI
     PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
     $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>
     $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/SCPI>
-    PRIVATE
-    ${CMAKE_CURRENT_SOURCE_DIR}
     )
 
 set_target_properties(SCPI PROPERTIES VERSION ${PROJECT_VERSION})


### PR DESCRIPTION
Notes:
* sec1000d does not use getCommand()
* zera-classes/scpimodule has a cSCPIDelegate (encapsulated by namespace) but
  that is a complete different story

Signed-off-by: Andreas Müller <schnitzeltony@gmail.com>