### PR TITLE
XmlElemCompareAttribs: Make sure the sequence of attributes is free

### DIFF
--- a/tests/test_xmlelemcompareattribs.cpp
+++ b/tests/test_xmlelemcompareattribs.cpp
@@ -111,6 +111,17 @@ void test_xmlelemcompareattribs::compareTwo()
     QVERIFY(XmlElemCompareAttribs::compare(*m_elem1, *m_elem2));
 }
 
+void test_xmlelemcompareattribs::compareTwoDiffOrder()
+{
+    QDomDocument doc1;
+    QVERIFY(doc1.setContent(QString("<root a='1' b='2'/>")));
+    QDomDocument doc2;
+    QVERIFY(doc2.setContent(QString("<root b='2' a='1'/>")));
+    QDomElement elem1 = doc1.firstChildElement();
+    QDomElement elem2 = doc2.firstChildElement();
+    QVERIFY(XmlElemCompareAttribs::compare(elem1, elem2));
+}
+
 void test_xmlelemcompareattribs::compareSameText()
 {
     QDomDocument doc;

--- a/tests/test_xmlelemcompareattribs.h
+++ b/tests/test_xmlelemcompareattribs.h
@@ -23,6 +23,7 @@ private slots:
     void compareTwoSecondValUnequal();
     void compareTwoDifferentAttribNames();
     void compareTwo();
+    void compareTwoDiffOrder();
     void compareSameText();
     void compareDiffText();
 private:


### PR DESCRIPTION
Signed-off-by: Andreas Müller <schnitzeltony@gmail.com>