### PR TITLE
cSCPIPrivate::delItemAndParents: Do not delete items recursively

### DIFF
--- a/src/scpi/scpi_p.cpp
+++ b/src/scpi/scpi_p.cpp
@@ -38,16 +38,15 @@ void cSCPIPrivate::insertScpiCmd(const QStringList& parentnodeNames, cSCPIObject
     }
 }
 
-void cSCPIPrivate::delItemAndParents(ScpiNode *Item)
+void cSCPIPrivate::delItemAndParents(ScpiNode *delItem)
 {
-    ScpiNode *parentItem = Item->parent();
-    if (parentItem) { // do we have a parent ?
-        if (parentItem->rowCount() == 1) { // if this item is the ony child of parent
-            parentItem->removeRow(0); // we delete it
-            delItemAndParents(parentItem); // and test if the parent has to be deleted too
-        }
-        else
-            parentItem->removeRow(Item->row());
+    while(delItem->parent()) {
+        int row = delItem->row();
+        ScpiNode *parent = delItem->parent();
+        parent->removeRow(row);
+        if(parent->rowCount() >= 1)
+            return;
+        delItem = parent;
     }
 }
 

--- a/src/scpi/scpi_p.h
+++ b/src/scpi/scpi_p.h
@@ -19,7 +19,7 @@ public:
 
 private:
     ScpiNode* createNode(const QString &name, quint8 type, cSCPIObject *scpiObject);
-    void delItemAndParents(ScpiNode* Item);
+    void delItemAndParents(ScpiNode* delItem);
     void appendScpiNodeXmlInfo(ScpiNode* rootItem, QDomDocument &doc, QDomElement &rootElement, const QStringList parentNames);
     static QString scpiTypeToString(quint8 scpiType);
     ScpiNode *findOrCreateChildParentItem(ScpiNode *parentItem, const QStringList& parentnodeNames);


### PR DESCRIPTION
* Deleting recursively possibly causes use after delete trouble
* the code to delete is simpler and easier to understand

Signed-off-by: Andreas Müller <schnitzeltony@gmail.com>