### PR TITLE
ScpiSingletonFactory: Use std template data types

### DIFF
--- a/scpi/lib/scpisingletonfactory.cpp
+++ b/scpi/lib/scpisingletonfactory.cpp
@@ -1,12 +1,12 @@
 #include "scpisingletonfactory.h"
 
-QHash<QString, ScpiSingletonFactory::scpiPtr> ScpiSingletonFactory::m_scpiHash;
+std::unordered_map<QString, ScpiSingletonFactory::scpiPtr> ScpiSingletonFactory::m_scpiHash;
 
 cSCPI* ScpiSingletonFactory::getScpiObj(QString name)
 {
     scpiPtr &entry = m_scpiHash[name];
     if(!entry) {
-        entry = scpiPtr::create(name);
+        entry = std::make_unique<cSCPI>(name);
     }
-    return entry.data();
+    return entry.get();
 }

--- a/scpi/lib/scpisingletonfactory.h
+++ b/scpi/lib/scpisingletonfactory.h
@@ -4,6 +4,7 @@
 #include <scpi.h>
 #include <QString>
 #include <memory>
+#include <unordered_map>
 
 class ScpiSingletonFactory
 {

--- a/scpi/lib/scpisingletonfactory.h
+++ b/scpi/lib/scpisingletonfactory.h
@@ -2,17 +2,16 @@
 #define SCPISINGLETONFACTORY_H
 
 #include <scpi.h>
-#include <QHash>
 #include <QString>
-#include <QSharedPointer>
+#include <memory>
 
 class ScpiSingletonFactory
 {
 public:
     static cSCPI* getScpiObj(QString name);
 private:
-    typedef QSharedPointer<cSCPI> scpiPtr;
-    static QHash<QString, scpiPtr> m_scpiHash;
+    typedef std::unique_ptr<cSCPI> scpiPtr;
+    static std::unordered_map<QString, scpiPtr> m_scpiHash;
 };
 
 #endif // SCPISINGLETONFACTORY_H


### PR DESCRIPTION
We started this because shared pointers are the wrong choice here. Since QHash requires copy constuctor which is not available on std::unique_ptr, QHash was replaced by std::unordered_map.

Signed-off-by: Andreas Müller <schnitzeltony@gmail.com>