### PR TITLE
Handle empty parent node names gracefully on insertion

### DIFF
--- a/scpi/lib/scpi_p.cpp
+++ b/scpi/lib/scpi_p.cpp
@@ -15,8 +15,10 @@ void cSCPIPrivate::insertScpiCmd(const QStringList& parentNodeNames, cSCPIObject
 {
     ScpiNode *parentNode = &m_invisibleRootNode;
     const QStringList parentNamesCleaned = removeEmptyNodes(parentNodeNames);
-    if(parentNamesCleaned.size() != parentNodeNames.size())
-        qWarning("SCPI: Removed empty parent node names in: '%s:%s'",
+    int nodesRemoved = parentNodeNames.size() - parentNamesCleaned.size();
+    if(nodesRemoved)
+        qWarning("SCPI: Removed %i empty parent node names in: '%s:%s'",
+                 nodesRemoved,
                  qPrintable(parentNodeNames.join(":")),
                  qPrintable(pSCPIObject->getName()));
     if(parentNamesCleaned.count() > 0)

--- a/scpi/lib/scpi_p.cpp
+++ b/scpi/lib/scpi_p.cpp
@@ -14,8 +14,9 @@ cSCPIPrivate::cSCPIPrivate(const QString &interfaceName) :
 void cSCPIPrivate::insertScpiCmd(const QStringList& parentNodeNames, cSCPIObject *pSCPIObject)
 {
     ScpiNode *parentNode = &m_invisibleRootNode;
-    if(parentNodeNames.count() > 0 && parentNodeNames.at(0) != "")
-        parentNode = findParentAndCreatePath(parentNodeNames);
+    const QStringList parentNamesCleaned = removeEmptyNodes(parentNodeNames);
+    if(parentNamesCleaned.count() > 0)
+        parentNode = findParentAndCreatePath(parentNamesCleaned);
     if(pSCPIObject)
         ScpiNodeStaticFunctions::addOrReplaceChild(parentNode, pSCPIObject);
 }
@@ -86,4 +87,11 @@ void cSCPIPrivate::findAndDeleteNode(const QStringList &nodePath)
         if(parentNode)
             ScpiNodeStaticFunctions::delNodeAndEmptyParents(parentNode);
     }
+}
+
+QStringList cSCPIPrivate::removeEmptyNodes(const QStringList &parentNodeNames)
+{
+    QStringList parentNodeNamesCleaned = parentNodeNames;
+    parentNodeNamesCleaned.removeAll("");
+    return parentNodeNamesCleaned;
 }

--- a/scpi/lib/scpi_p.cpp
+++ b/scpi/lib/scpi_p.cpp
@@ -93,5 +93,7 @@ QStringList cSCPIPrivate::removeEmptyNodes(const QStringList &parentNodeNames)
 {
     QStringList parentNodeNamesCleaned = parentNodeNames;
     parentNodeNamesCleaned.removeAll("");
+    if(parentNodeNamesCleaned.size() != parentNodeNames.size())
+        qWarning("SCPI: Removed empty parent node names in: '%s'", qPrintable(parentNodeNames.join(":")));
     return parentNodeNamesCleaned;
 }

--- a/scpi/lib/scpi_p.cpp
+++ b/scpi/lib/scpi_p.cpp
@@ -15,6 +15,10 @@ void cSCPIPrivate::insertScpiCmd(const QStringList& parentNodeNames, cSCPIObject
 {
     ScpiNode *parentNode = &m_invisibleRootNode;
     const QStringList parentNamesCleaned = removeEmptyNodes(parentNodeNames);
+    if(parentNamesCleaned.size() != parentNodeNames.size())
+        qWarning("SCPI: Removed empty parent node names in: '%s:%s'",
+                 qPrintable(parentNodeNames.join(":")),
+                 qPrintable(pSCPIObject->getName()));
     if(parentNamesCleaned.count() > 0)
         parentNode = findParentAndCreatePath(parentNamesCleaned);
     if(pSCPIObject)
@@ -93,7 +97,5 @@ QStringList cSCPIPrivate::removeEmptyNodes(const QStringList &parentNodeNames)
 {
     QStringList parentNodeNamesCleaned = parentNodeNames;
     parentNodeNamesCleaned.removeAll("");
-    if(parentNodeNamesCleaned.size() != parentNodeNames.size())
-        qWarning("SCPI: Removed empty parent node names in: '%s'", qPrintable(parentNodeNames.join(":")));
     return parentNodeNamesCleaned;
 }

--- a/scpi/lib/scpi_p.h
+++ b/scpi/lib/scpi_p.h
@@ -18,6 +18,7 @@ public:
 private:
     ScpiNode *findParentAndCreatePath(const QStringList& parentNodePath);
     void findAndDeleteNode(const QStringList &nodePath);
+    QStringList removeEmptyNodes(const QStringList& parentNodeNames);
 
     ScpiNode m_invisibleRootNode;
     QString m_interfaceName;

--- a/scpi/tests/test_scpiinterface.cpp
+++ b/scpi/tests/test_scpiinterface.cpp
@@ -191,3 +191,19 @@ void test_scpiinterface::addFindTwoWithSameShortButDifferentLong()
     QCOMPARE(interface.getSCPIObject(QString("conf:rng1:foo")), &obj1);
     QCOMPARE(interface.getSCPIObject(QString("conf:rng2:bar")), &obj2);
 }
+
+void test_scpiinterface::emptyParentNodeCorrection()
+{
+    cSCPI interface("dev");
+    SCPITestObjectStub obj("foo", SCPI::isQuery);
+    interface.insertScpiCmd(QStringList() << "root" << "" << "child", &obj);
+    QCOMPARE(interface.getSCPIObject(QString("root:child:foo")), &obj);
+}
+
+void test_scpiinterface::emptyParentNodeCorrectionMultiple()
+{
+    cSCPI interface("dev");
+    SCPITestObjectStub obj("foo", SCPI::isQuery);
+    interface.insertScpiCmd(QStringList() << "" << "" << "root" << "" << "child", &obj);
+    QCOMPARE(interface.getSCPIObject(QString("root:child:foo")), &obj);
+}

--- a/scpi/tests/test_scpiinterface.h
+++ b/scpi/tests/test_scpiinterface.h
@@ -24,6 +24,8 @@ private slots:
     void addFindExactShortLongVowelO();
     void addFindExactShortLongVowelU();
     void addFindTwoWithSameShortButDifferentLong();
+    void emptyParentNodeCorrection();
+    void emptyParentNodeCorrectionMultiple();
 };
 
 #endif // TEST_SCPIINTERFACE_H


### PR DESCRIPTION
It took a long nasty remote debug to find that we just broke zenux-services by a cleanup session. To avoid this once and for all in future we:

* ignore empty path names - they are not valid and usually results accidents
* create a warning to enable finding and fixing properly

Signed-off-by: Andreas Müller <schnitzeltony@gmail.com>