### PR TITLE
scpi_p/exportSCPIModelXML: Change the api

### DIFF
--- a/scpi/lib/scpi.cpp
+++ b/scpi/lib/scpi.cpp
@@ -6,8 +6,8 @@
 #include "scpi.h"
 #include "scpi_p.h"
 
-cSCPI::cSCPI(QString interfaceName)
-    :d_ptr(new cSCPIPrivate(interfaceName))
+cSCPI::cSCPI()
+    :d_ptr(new cSCPIPrivate())
 {
 }
 
@@ -41,7 +41,7 @@ cSCPIObject* cSCPI::getSCPIObject(const cSCPICommand &input) const
     return getSCPIObject(input.getCommand());
 }
 
-void cSCPI::exportSCPIModelXML(QString &sxml)
+void cSCPI::exportSCPIModelXML(QString &sxml, QMap<QString, QString> modelListBaseEntry)
 {
-    d_ptr->exportSCPIModelXML(sxml);
+    d_ptr->exportSCPIModelXML(sxml, modelListBaseEntry);
 }

--- a/scpi/lib/scpi.h
+++ b/scpi/lib/scpi.h
@@ -22,6 +22,7 @@
 #include <QStringList>
 #include <QString>
 #include <QList>
+#include <QMap>
 #include "scpi_export.h"
 #include "scpiobject.h"
 #include "scpicommand.h"
@@ -52,7 +53,7 @@ class cSCPIPrivate;
 class SCPI_EXPORT cSCPI
 {
 public:
-    cSCPI(QString interfaceName);
+    cSCPI();
     virtual ~cSCPI();
 
     void insertScpiCmd(const QStringList& parentNodeNames, cSCPIObject* pSCPIObject);
@@ -63,7 +64,7 @@ public:
     cSCPIObject* getSCPIObject(const QString& input) const;
     cSCPIObject* getSCPIObject(const cSCPICommand &input) const;
 
-    void exportSCPIModelXML(QString &sxml);
+    void exportSCPIModelXML(QString &sxml, QMap<QString, QString> modelListBaseEntry = QMap<QString, QString>());
 private:
     cSCPIPrivate *d_ptr;
 };

--- a/scpi/lib/scpi_p.cpp
+++ b/scpi/lib/scpi_p.cpp
@@ -5,9 +5,8 @@
 #include <QDomElement>
 #include <QList>
 
-cSCPIPrivate::cSCPIPrivate(const QString &interfaceName) :
-    m_invisibleRootNode(QString(), nullptr),
-    m_interfaceName(interfaceName)
+cSCPIPrivate::cSCPIPrivate() :
+    m_invisibleRootNode(QString(), nullptr)
 {
 }
 
@@ -46,17 +45,19 @@ cSCPIObject* cSCPIPrivate::getSCPIObject(const QString& input)
     return nullptr;
 }
 
-void cSCPIPrivate::exportSCPIModelXML(QString& sxml)
+void cSCPIPrivate::exportSCPIModelXML(QString& sxml, QMap<QString, QString> modelListBaseEntry)
 {
     QDomDocument modelDoc("SCPIModel");
 
     QDomElement rootTag = modelDoc.createElement("MODELLIST");
     modelDoc.appendChild(rootTag);
 
-    QDomElement deviceTag = modelDoc.createElement("DEVICE");
-    rootTag.appendChild( deviceTag );
-    QDomText t = modelDoc.createTextNode(m_interfaceName);
-    deviceTag.appendChild(t);
+    for(auto iter=modelListBaseEntry.constBegin(); iter!=modelListBaseEntry.constEnd(); iter++) {
+        QDomElement elem = modelDoc.createElement(iter.key());
+        rootTag.appendChild(elem);
+        QDomText domText = modelDoc.createTextNode(iter.value());
+        elem.appendChild(domText);
+    }
 
     QDomElement modelsTag = modelDoc.createElement("MODELS");
     rootTag.appendChild(modelsTag);

--- a/scpi/lib/scpi_p.h
+++ b/scpi/lib/scpi_p.h
@@ -10,18 +10,17 @@
 class cSCPIPrivate
 {
 public:
-    cSCPIPrivate(const QString& interfaceName);
+    cSCPIPrivate();
     void insertScpiCmd(const QStringList& parentNodeNames, cSCPIObject* pSCPIObject);
     void delSCPICmds(const QString& cmd);
     cSCPIObject* getSCPIObject(const QString& input);
-    void exportSCPIModelXML(QString &sxml);
+    void exportSCPIModelXML(QString &sxml, QMap<QString, QString> modelListBaseEntry);
 private:
     ScpiNode *findParentAndCreatePath(const QStringList& parentNodePath);
     void findAndDeleteNode(const QStringList &nodePath);
     QStringList removeEmptyNodes(const QStringList& parentNodeNames);
 
     ScpiNode m_invisibleRootNode;
-    QString m_interfaceName;
     cParse m_Parser;
 };
 

--- a/scpi/lib/scpisingletonfactory.cpp
+++ b/scpi/lib/scpisingletonfactory.cpp
@@ -1,12 +1,11 @@
 #include "scpisingletonfactory.h"
 
-std::unordered_map<QString, ScpiSingletonFactory::scpiPtr> ScpiSingletonFactory::m_scpiHash;
+cSCPI* ScpiSingletonFactory::m_instance = nullptr;
 
-cSCPI* ScpiSingletonFactory::getScpiObj(QString name)
+cSCPI* ScpiSingletonFactory::getScpiObj()
 {
-    scpiPtr &entry = m_scpiHash[name];
-    if(!entry) {
-        entry = std::make_unique<cSCPI>(name);
+    if(!m_instance) {
+        m_instance = new cSCPI();
     }
-    return entry.get();
+    return m_instance;
 }

--- a/scpi/lib/scpisingletonfactory.h
+++ b/scpi/lib/scpisingletonfactory.h
@@ -9,10 +9,9 @@
 class ScpiSingletonFactory
 {
 public:
-    static cSCPI* getScpiObj(QString name);
+    static cSCPI* getScpiObj();
 private:
-    typedef std::unique_ptr<cSCPI> scpiPtr;
-    static std::unordered_map<QString, scpiPtr> m_scpiHash;
+    static cSCPI* m_instance;
 };
 
 #endif // SCPISINGLETONFACTORY_H

--- a/scpi/testlibs/scpi-testlib/scpifullcmdcheckerfortest.cpp
+++ b/scpi/testlibs/scpi-testlib/scpifullcmdcheckerfortest.cpp
@@ -1,13 +1,11 @@
 #include "scpifullcmdcheckerfortest.h"
 #include "scpiparamcheckerdelegate.h"
 
-ScpiFullCmdCheckerForTest::ScpiFullCmdCheckerForTest() :
-    m_scpiTree("TestScpi")
+ScpiFullCmdCheckerForTest::ScpiFullCmdCheckerForTest()
 {
 }
 
-ScpiFullCmdCheckerForTest::ScpiFullCmdCheckerForTest(QString scpiNodePath, quint8 scpiType, int paramCountExpected) :
-    m_scpiTree("TestScpi")
+ScpiFullCmdCheckerForTest::ScpiFullCmdCheckerForTest(QString scpiNodePath, quint8 scpiType, int paramCountExpected)
 {
     addCommand(scpiNodePath, scpiType, paramCountExpected);
 }

--- a/scpi/tests/test_scpibenchmark.cpp
+++ b/scpi/tests/test_scpibenchmark.cpp
@@ -10,7 +10,7 @@ static const int treeDepth = 4;
 
 void test_scpibenchmark::initTestCase()
 {
-    m_scpiInterface = new cSCPI("dev");
+    m_scpiInterface = new cSCPI();
 }
 
 void test_scpibenchmark::cleanupTestCase()

--- a/scpi/tests/test_scpiinterface.cpp
+++ b/scpi/tests/test_scpiinterface.cpp
@@ -7,7 +7,7 @@ QTEST_MAIN(test_scpiinterface)
 
 void test_scpiinterface::mostSimpleAddFindAndLearnBehaviour()
 {
-    cSCPI interface("dev");
+    cSCPI interface;
     SCPITestObjectStub obj("foo", SCPI::isQuery);
     interface.insertScpiCmd(QStringList() << "rootitem", &obj);
     // We learned here:
@@ -27,13 +27,13 @@ void test_scpiinterface::mostSimpleAddFindAndLearnBehaviour()
 
 void test_scpiinterface::findEmpty()
 {
-    cSCPI interface("dev");
+    cSCPI interface;
     QCOMPARE(interface.getSCPIObject(QString("root:foo")), nullptr);
 }
 
 void test_scpiinterface::addRoot()
 {
-    cSCPI interface("dev");
+    cSCPI interface;
     SCPITestObjectStub obj("foo", SCPI::isQuery);
     interface.insertScpiCmd(QStringList(), &obj);
     QCOMPARE(interface.getSCPIObject(QString("foo")), &obj);
@@ -41,7 +41,7 @@ void test_scpiinterface::addRoot()
 
 void test_scpiinterface::addFindTwoRoot()
 {
-    cSCPI interface("dev");
+    cSCPI interface;
     SCPITestObjectStub obj1("foo", SCPI::isQuery);
     interface.insertScpiCmd(QStringList() << "root1", &obj1);
     SCPITestObjectStub obj2("bar", SCPI::isQuery);
@@ -52,7 +52,7 @@ void test_scpiinterface::addFindTwoRoot()
 
 void test_scpiinterface::addFindTwoNestedSamePath()
 {
-    cSCPI interface("dev");
+    cSCPI interface;
     SCPITestObjectStub obj1("foo", SCPI::isQuery);
     interface.insertScpiCmd(QStringList() << "root" << "child", &obj1);
     SCPITestObjectStub obj2("bar", SCPI::isQuery);
@@ -63,7 +63,7 @@ void test_scpiinterface::addFindTwoNestedSamePath()
 
 void test_scpiinterface::addFindTwoIdenticalSecondOverwrites()
 {
-    cSCPI interface("dev");
+    cSCPI interface;
     SCPITestObjectStub obj1("foo", SCPI::isQuery);
     interface.insertScpiCmd(QStringList() << "root" << "child", &obj1);
     SCPITestObjectStub obj2("foo", SCPI::isQuery);
@@ -73,7 +73,7 @@ void test_scpiinterface::addFindTwoIdenticalSecondOverwrites()
 
 void test_scpiinterface::addFindTwoNestedDiffPath()
 {
-    cSCPI interface("dev");
+    cSCPI interface;
     SCPITestObjectStub obj1("foo", SCPI::isQuery);
     interface.insertScpiCmd(QStringList() << "root1" << "child1", &obj1);
     SCPITestObjectStub obj2("bar", SCPI::isQuery);
@@ -84,7 +84,7 @@ void test_scpiinterface::addFindTwoNestedDiffPath()
 
 void test_scpiinterface::addFindTwoNestedAlmostDiffPath()
 {
-    cSCPI interface("dev");
+    cSCPI interface;
     SCPITestObjectStub obj1("foo", SCPI::isQuery);
     interface.insertScpiCmd(QStringList() << "root" << "child1", &obj1);
     SCPITestObjectStub obj2("bar", SCPI::isQuery);
@@ -95,7 +95,7 @@ void test_scpiinterface::addFindTwoNestedAlmostDiffPath()
 
 void test_scpiinterface::addFindCaseInsensitive1()
 {
-    cSCPI interface("dev");
+    cSCPI interface;
     SCPITestObjectStub obj1("xxxx", SCPI::isQuery);
     interface.insertScpiCmd(QStringList() << "root" << "child", &obj1);
     SCPITestObjectStub obj2("XXXX", SCPI::isQuery);
@@ -106,7 +106,7 @@ void test_scpiinterface::addFindCaseInsensitive1()
 
 void test_scpiinterface::addFindCaseInsensitive2()
 {
-    cSCPI interface("dev");
+    cSCPI interface;
     SCPITestObjectStub obj1("XXXX", SCPI::isQuery);
     interface.insertScpiCmd(QStringList() << "ROOT" << "CHILD", &obj1);
     SCPITestObjectStub obj2("xxxx", SCPI::isQuery);
@@ -117,7 +117,7 @@ void test_scpiinterface::addFindCaseInsensitive2()
 
 void test_scpiinterface::addFindExactShortLong()
 {
-    cSCPI interface("dev");
+    cSCPI interface;
     SCPITestObjectStub obj1("xxxxxx", SCPI::isQuery);
     interface.insertScpiCmd(QStringList() << "bbbbbb", &obj1);
     QCOMPARE(interface.getSCPIObject(QString("bbbb:xxxx")), &obj1);
@@ -128,7 +128,7 @@ void test_scpiinterface::addFindExactShortLong()
 
 void test_scpiinterface::addFindExactShortLongVowelA()
 {
-    cSCPI interface("dev");
+    cSCPI interface;
     SCPITestObjectStub obj1("x", SCPI::isQuery);
     interface.insertScpiCmd(QStringList() << "aaaaaa", &obj1);
     QCOMPARE(interface.getSCPIObject(QString("aaa:x")), &obj1);
@@ -139,7 +139,7 @@ void test_scpiinterface::addFindExactShortLongVowelA()
 
 void test_scpiinterface::addFindExactShortLongVowelE()
 {
-    cSCPI interface("dev");
+    cSCPI interface;
     SCPITestObjectStub obj1("x", SCPI::isQuery);
     interface.insertScpiCmd(QStringList() << "eeeeee", &obj1);
     QCOMPARE(interface.getSCPIObject(QString("eee:x")), &obj1);
@@ -150,7 +150,7 @@ void test_scpiinterface::addFindExactShortLongVowelE()
 
 void test_scpiinterface::addFindExactShortLongVowelI()
 {
-    cSCPI interface("dev");
+    cSCPI interface;
     SCPITestObjectStub obj1("x", SCPI::isQuery);
     interface.insertScpiCmd(QStringList() << "iiiiii", &obj1);
     QCOMPARE(interface.getSCPIObject(QString("iii:x")), &obj1);
@@ -161,7 +161,7 @@ void test_scpiinterface::addFindExactShortLongVowelI()
 
 void test_scpiinterface::addFindExactShortLongVowelO()
 {
-    cSCPI interface("dev");
+    cSCPI interface;
     SCPITestObjectStub obj1("x", SCPI::isQuery);
     interface.insertScpiCmd(QStringList() << "oooooo", &obj1);
     QCOMPARE(interface.getSCPIObject(QString("ooo:x")), &obj1);
@@ -172,7 +172,7 @@ void test_scpiinterface::addFindExactShortLongVowelO()
 
 void test_scpiinterface::addFindExactShortLongVowelU()
 {
-    cSCPI interface("dev");
+    cSCPI interface;
     SCPITestObjectStub obj1("x", SCPI::isQuery);
     interface.insertScpiCmd(QStringList() << "uuuuuu", &obj1);
     QCOMPARE(interface.getSCPIObject(QString("uuu:x")), &obj1);
@@ -183,7 +183,7 @@ void test_scpiinterface::addFindExactShortLongVowelU()
 
 void test_scpiinterface::addFindTwoWithSameShortButDifferentLong()
 {
-    cSCPI interface("dev");
+    cSCPI interface;
     SCPITestObjectStub obj1("foo", SCPI::isQuery);
     interface.insertScpiCmd(QStringList() << "configure" << "rng1", &obj1);
     SCPITestObjectStub obj2("bar", SCPI::isQuery);
@@ -194,7 +194,7 @@ void test_scpiinterface::addFindTwoWithSameShortButDifferentLong()
 
 void test_scpiinterface::emptyParentNodeCorrection()
 {
-    cSCPI interface("dev");
+    cSCPI interface;
     SCPITestObjectStub obj("foo", SCPI::isQuery);
     interface.insertScpiCmd(QStringList() << "root" << "" << "child", &obj);
     QCOMPARE(interface.getSCPIObject(QString("root:child:foo")), &obj);
@@ -202,7 +202,7 @@ void test_scpiinterface::emptyParentNodeCorrection()
 
 void test_scpiinterface::emptyParentNodeCorrectionMultiple()
 {
-    cSCPI interface("dev");
+    cSCPI interface;
     SCPITestObjectStub obj("foo", SCPI::isQuery);
     interface.insertScpiCmd(QStringList() << "" << "" << "root" << "" << "child", &obj);
     QCOMPARE(interface.getSCPIObject(QString("root:child:foo")), &obj);

--- a/scpi/tests/test_scpiinterfacexml.cpp
+++ b/scpi/tests/test_scpiinterfacexml.cpp
@@ -6,8 +6,10 @@
 
 QTEST_MAIN(test_scpiinterfacexml)
 
-QString xmlLead = "<!DOCTYPE SCPIModel><MODELLIST><DEVICE>dev</DEVICE><MODELS>";
-QString xmlTrail = "</MODELS></MODELLIST>";
+QString xmlLead = "<!DOCTYPE SCPIModel><MODELLIST>";
+QString xmlModelsLead = "<MODELS>";
+QString xmlModelsTrail = "</MODELS>";
+QString xmlTrail = "</MODELLIST>";
 
 void test_scpiinterfacexml::addEmptyRoot()
 {
@@ -17,7 +19,7 @@ void test_scpiinterfacexml::addEmptyRoot()
     QString scpiModelXml =
             "<ROOT Type='Model,Node'>"
             "</ROOT>";
-    const QString xmlExpected = xmlLead + scpiModelXml + xmlTrail;
+    const QString xmlExpected = xmlLead + xmlModelsLead + scpiModelXml + xmlModelsTrail + xmlTrail;
     XmlDocumentCompare cmp;
     QVERIFY(cmp.compareXml(xmlExport, xmlExpected, true));
 }
@@ -31,7 +33,7 @@ void test_scpiinterfacexml::addEmptyRootNested()
             "<ROOT Type='Model,Node'>"
                 "<CHILD Type='Node'/>"
             "</ROOT>";
-    const QString xmlExpected = xmlLead + scpiModelXml + xmlTrail;
+    const QString xmlExpected = xmlLead + xmlModelsLead + scpiModelXml + xmlModelsTrail + xmlTrail;
     XmlDocumentCompare cmp;
     QVERIFY(cmp.compareXml(xmlExport, xmlExpected, true));
 }
@@ -47,7 +49,7 @@ void test_scpiinterfacexml::oneQuery()
             "<ROOT Type='Model,Node'>"
                 "<FOO ScpiPath='ROOT:FOO' Type='Query'/>"
             "</ROOT>";
-    const QString xmlExpected = xmlLead + scpiModelXml + xmlTrail;
+    const QString xmlExpected = xmlLead + xmlModelsLead + scpiModelXml + xmlModelsTrail + xmlTrail;
 
     XmlDocumentCompare cmp;
     QVERIFY(cmp.compareXml(xmlExport, xmlExpected, true));
@@ -65,7 +67,7 @@ void test_scpiinterfacexml::oneCmd()
             "<ROOT Type='Model,Node'>"
                 "<FOO ScpiPath='ROOT:FOO' Type='Command'/>"
             "</ROOT>";
-    const QString xmlExpected = xmlLead + scpiModelXml + xmlTrail;
+    const QString xmlExpected = xmlLead + xmlModelsLead + scpiModelXml + xmlModelsTrail + xmlTrail;
 
     XmlDocumentCompare cmp;
     QVERIFY(cmp.compareXml(xmlExport, xmlExpected, true));
@@ -82,7 +84,7 @@ void test_scpiinterfacexml::oneCmdwP()
             "<ROOT Type='Model,Node'>"
                 "<FOO ScpiPath='ROOT:FOO' Type='Command+Par'/>"
             "</ROOT>";
-    const QString xmlExpected = xmlLead + scpiModelXml + xmlTrail;
+    const QString xmlExpected = xmlLead + xmlModelsLead + scpiModelXml + xmlModelsTrail + xmlTrail;
 
     XmlDocumentCompare cmp;
     QVERIFY(cmp.compareXml(xmlExport, xmlExpected, true));
@@ -99,7 +101,7 @@ void test_scpiinterfacexml::oneXMLCmd()
             "<ROOT Type='Model,Node'>"
                 "<FOO ScpiPath='ROOT:FOO' Type=''/>"
             "</ROOT>";
-    const QString xmlExpected = xmlLead + scpiModelXml + xmlTrail;
+    const QString xmlExpected = xmlLead + xmlModelsLead + scpiModelXml + xmlModelsTrail + xmlTrail;
 
     XmlDocumentCompare cmp;
     QVERIFY(cmp.compareXml(xmlExport, xmlExpected, true));
@@ -120,7 +122,7 @@ void test_scpiinterfacexml::oneElementNested()
                     "</CHILD1>"
                 "</CHILD>"
             "</ROOT>";
-    const QString xmlExpected = xmlLead + scpiModelXml + xmlTrail;
+    const QString xmlExpected = xmlLead + xmlModelsLead + scpiModelXml + xmlModelsTrail + xmlTrail;
 
     XmlDocumentCompare cmp;
     QVERIFY(cmp.compareXml(xmlExport, xmlExpected, true));
@@ -149,7 +151,7 @@ void test_scpiinterfacexml::twoElementNestedDifferentPath()
                     "</CHILD4>"
                 "</CHILD3>"
             "</ROOT2>";
-    const QString xmlExpected = xmlLead + scpiModelXml + xmlTrail;
+    const QString xmlExpected = xmlLead + xmlModelsLead + scpiModelXml + xmlModelsTrail + xmlTrail;
 
     XmlDocumentCompare cmp;
     QVERIFY(cmp.compareXml(xmlExport, xmlExpected, true));
@@ -173,7 +175,7 @@ void test_scpiinterfacexml::twoElementNestedSamePath()
                     "</CHILD2>"
                 "</CHILD1>"
             "</ROOT1>";
-    const QString xmlExpected = xmlLead + scpiModelXml + xmlTrail;
+    const QString xmlExpected = xmlLead + xmlModelsLead + scpiModelXml + xmlModelsTrail + xmlTrail;
 
     XmlDocumentCompare cmp;
     QVERIFY(cmp.compareXml(xmlExport, xmlExpected, true));
@@ -198,7 +200,7 @@ void test_scpiinterfacexml::twoElementNestedAlmostSamePath()
                     "</CHILD3>"
                 "</CHILD1>"
             "</ROOT1>";
-    const QString xmlExpected = xmlLead + scpiModelXml + xmlTrail;
+    const QString xmlExpected = xmlLead + xmlModelsLead + scpiModelXml + xmlModelsTrail + xmlTrail;
 
     XmlDocumentCompare cmp;
     QVERIFY(cmp.compareXml(xmlExport, xmlExpected, true));
@@ -213,7 +215,7 @@ void test_scpiinterfacexml::oneElementNestedRemove()
     QCOMPARE(ScpiNode::getInstanceCount(), 1);
 
     QString xmlExport = createScpiString();
-    const QString xmlExpected = xmlLead + xmlTrail;
+    const QString xmlExpected = xmlLead + xmlModelsLead + xmlModelsTrail + xmlTrail;
 
     XmlDocumentCompare cmp;
     QVERIFY(cmp.compareXml(xmlExport, xmlExpected, true));
@@ -242,7 +244,7 @@ void test_scpiinterfacexml::oneElementNestedRemoveReAdd()
                     "</CHILD1>"
                 "</CHILD>"
             "</ROOT1>";
-    const QString xmlExpected = xmlLead + scpiModelXml + xmlTrail;
+    const QString xmlExpected = xmlLead + xmlModelsLead + scpiModelXml + xmlModelsTrail + xmlTrail;
 
     XmlDocumentCompare cmp;
     QVERIFY(cmp.compareXml(xmlExport, xmlExpected, true));
@@ -266,7 +268,7 @@ void test_scpiinterfacexml::twoElementNestedSamePathRemoveFirst()
                     "</CHILD2>"
                 "</CHILD1>"
             "</ROOT1>";
-    const QString xmlExpected = xmlLead + scpiModelXml + xmlTrail;
+    const QString xmlExpected = xmlLead + xmlModelsLead + scpiModelXml + xmlModelsTrail + xmlTrail;
 
     XmlDocumentCompare cmp;
     QVERIFY(cmp.compareXml(xmlExport, xmlExpected, true));
@@ -290,7 +292,7 @@ void test_scpiinterfacexml::twoElementNestedSamePathRemoveFirstUpperCase()
                     "</CHILD2>"
                 "</CHILD1>"
             "</ROOT1>";
-    const QString xmlExpected = xmlLead + scpiModelXml + xmlTrail;
+    const QString xmlExpected = xmlLead + xmlModelsLead + scpiModelXml + xmlModelsTrail + xmlTrail;
 
     XmlDocumentCompare cmp;
     QVERIFY(cmp.compareXml(xmlExport, xmlExpected, true));
@@ -315,7 +317,7 @@ void test_scpiinterfacexml::twoElementNestedSamePathRemoveNonExistent()
                     "</CHILD2>"
                 "</CHILD1>"
             "</ROOT1>";
-    const QString xmlExpected = xmlLead + scpiModelXml + xmlTrail;
+    const QString xmlExpected = xmlLead + xmlModelsLead + scpiModelXml + xmlModelsTrail + xmlTrail;
 
     XmlDocumentCompare cmp;
     QVERIFY(cmp.compareXml(xmlExport, xmlExpected, true));
@@ -331,7 +333,7 @@ void test_scpiinterfacexml::twoElementNestedSamePathRemoveParent()
     QCOMPARE(ScpiNode::getInstanceCount(), 1);
 
     QString xmlExport = createScpiString();
-    const QString xmlExpected = xmlLead + xmlTrail;
+    const QString xmlExpected = xmlLead + xmlModelsLead + xmlModelsTrail + xmlTrail;
 
     XmlDocumentCompare cmp;
     QVERIFY(cmp.compareXml(xmlExport, xmlExpected, true));
@@ -347,7 +349,7 @@ void test_scpiinterfacexml::twoElementNestedSamePathRemoveGrandParent()
     QCOMPARE(ScpiNode::getInstanceCount(), 1);
 
     QString xmlExport = createScpiString();
-    const QString xmlExpected = xmlLead + xmlTrail;
+    const QString xmlExpected = xmlLead + xmlModelsLead + xmlModelsTrail + xmlTrail;
 
     XmlDocumentCompare cmp;
     QVERIFY(cmp.compareXml(xmlExport, xmlExpected, true));
@@ -373,7 +375,7 @@ void test_scpiinterfacexml::twoElementNestedRemoveHalfUp()
                     "</CHILD2>"
                 "</CHILD1>"
             "</ROOT1>";
-    const QString xmlExpected = xmlLead + scpiModelXml + xmlTrail;
+    const QString xmlExpected = xmlLead + xmlModelsLead + scpiModelXml + xmlModelsTrail + xmlTrail;
 
     XmlDocumentCompare cmp;
     QVERIFY(cmp.compareXml(xmlExport, xmlExpected, true));
@@ -395,7 +397,7 @@ void test_scpiinterfacexml::threeElementAddRemoveFirstThirdWhichIsSecondAfterFir
             "<ROOT Type='Model,Node'>"
                 "<CHILD2 ScpiPath='ROOT:CHILD2' Type='Query'/>"
             "</ROOT>";
-    const QString xmlExpected = xmlLead + scpiModelXml + xmlTrail;
+    const QString xmlExpected = xmlLead + xmlModelsLead + scpiModelXml + xmlModelsTrail + xmlTrail;
 
     XmlDocumentCompare cmp;
     QVERIFY(cmp.compareXml(xmlExport, xmlExpected, true));
@@ -414,8 +416,39 @@ void test_scpiinterfacexml::twoDifferentCase()
             "<ROOT Type='Model,Node'>"
                 "<CHILD ScpiPath='ROOT:CHILD' Type='Query'/>"
             "</ROOT>";
-    const QString xmlExpected = xmlLead + scpiModelXml + xmlTrail;
+    const QString xmlExpected = xmlLead + xmlModelsLead + scpiModelXml + xmlModelsTrail + xmlTrail;
 
+    XmlDocumentCompare cmp;
+    QVERIFY(cmp.compareXml(xmlExport, xmlExpected, true));
+}
+
+void test_scpiinterfacexml::oneModelListBaseEntry()
+{
+    m_scpiInterface->insertScpiCmd(QStringList() << "root", nullptr);
+    QMap<QString, QString> modelListBaseEntry;
+    modelListBaseEntry.insert("key", "value");
+    QString xmlExport = createScpiString(modelListBaseEntry);
+
+    QString scpiModelXml =
+            "<ROOT Type='Model,Node'>"
+            "</ROOT>";
+    const QString xmlExpected = xmlLead + "<key>value</key>" + xmlModelsLead + scpiModelXml + xmlModelsTrail + xmlTrail;
+    XmlDocumentCompare cmp;
+    QVERIFY(cmp.compareXml(xmlExport, xmlExpected, true));
+}
+
+void test_scpiinterfacexml::twoModelListBaseEntries()
+{
+    m_scpiInterface->insertScpiCmd(QStringList() << "root", nullptr);
+    QMap<QString, QString> modelListBaseEntry;
+    modelListBaseEntry.insert("key1", "value1");
+    modelListBaseEntry.insert("key2", "value2");
+    QString xmlExport = createScpiString(modelListBaseEntry);
+
+    QString scpiModelXml =
+            "<ROOT Type='Model,Node'>"
+            "</ROOT>";
+    const QString xmlExpected = xmlLead + "<key1>value1</key1>" + "<key2>value2</key2>" + xmlModelsLead + scpiModelXml + xmlModelsTrail + xmlTrail;
     XmlDocumentCompare cmp;
     QVERIFY(cmp.compareXml(xmlExport, xmlExpected, true));
 }
@@ -428,7 +461,7 @@ void test_scpiinterfacexml::iteminstanceCountInit()
 void test_scpiinterfacexml::init()
 {
     QCOMPARE(ScpiNode::getInstanceCount(), 0);
-    m_scpiInterface = new cSCPI("dev");
+    m_scpiInterface = new cSCPI();
 }
 
 void test_scpiinterfacexml::cleanup()
@@ -449,10 +482,10 @@ void test_scpiinterfacexml::addScpiObjects(QList<ScpiNodeInfo> scpiNodes)
     }
 }
 
-QString test_scpiinterfacexml::createScpiString()
+QString test_scpiinterfacexml::createScpiString(QMap<QString, QString> modelListBaseEntry)
 {
     QString exportedXml;
-    m_scpiInterface->exportSCPIModelXML(exportedXml);
+    m_scpiInterface->exportSCPIModelXML(exportedXml, modelListBaseEntry);
     return exportedXml;
 }
 

--- a/scpi/tests/test_scpiinterfacexml.h
+++ b/scpi/tests/test_scpiinterfacexml.h
@@ -35,6 +35,9 @@ private slots:
 
     void twoDifferentCase();
 
+    void oneModelListBaseEntry();
+    void twoModelListBaseEntries();
+
     void iteminstanceCountInit();
 
     void init();
@@ -47,7 +50,7 @@ private:
     };
 
     void addScpiObjects(QList<ScpiNodeInfo> scpiNodes);
-    QString createScpiString();
+    QString createScpiString(QMap<QString, QString> modelListBaseEntry = QMap<QString, QString>());
 
     QList<SCPITestObjectStub*> m_perTestScpiObjects;
     cSCPI *m_scpiInterface;

--- a/scpi/tests/test_scpisingletonfactory.cpp
+++ b/scpi/tests/test_scpisingletonfactory.cpp
@@ -5,35 +5,12 @@ QTEST_MAIN(test_scpisingletonfactory)
 
 void test_scpisingletonfactory::askOneOnce()
 {
-   QVERIFY(ScpiSingletonFactory::getScpiObj("foo"));
+   QVERIFY(ScpiSingletonFactory::getScpiObj());
 }
 
 void test_scpisingletonfactory::askOneTwice()
 {
-    cSCPI* ptr1 = ScpiSingletonFactory::getScpiObj("foo");
-    cSCPI* ptr2 = ScpiSingletonFactory::getScpiObj("foo");
+    cSCPI* ptr1 = ScpiSingletonFactory::getScpiObj();
+    cSCPI* ptr2 = ScpiSingletonFactory::getScpiObj();
     QCOMPARE(ptr1, ptr2);
-}
-
-void test_scpisingletonfactory::askTwoOnce()
-{
-    cSCPI* foo = ScpiSingletonFactory::getScpiObj("foo");
-    cSCPI* bar = ScpiSingletonFactory::getScpiObj("bar");
-    QVERIFY(foo);
-    QVERIFY(bar);
-    QVERIFY(foo != bar);
-}
-
-void test_scpisingletonfactory::askTwoTwice()
-{
-    cSCPI* foo1 = ScpiSingletonFactory::getScpiObj("foo");
-    cSCPI* foo2 = ScpiSingletonFactory::getScpiObj("foo");
-    cSCPI* bar1 = ScpiSingletonFactory::getScpiObj("bar");
-    cSCPI* bar2 = ScpiSingletonFactory::getScpiObj("bar");
-    QVERIFY(foo1);
-    QCOMPARE(foo1, foo2);
-    QVERIFY(bar1);
-    QCOMPARE(bar1, bar2);
-    QVERIFY(foo1 != bar1);
-    QVERIFY(foo2 != bar2);
 }

--- a/scpi/tests/test_scpisingletonfactory.h
+++ b/scpi/tests/test_scpisingletonfactory.h
@@ -9,8 +9,6 @@ class test_scpisingletonfactory : public QObject
 private slots:
     void askOneOnce();
     void askOneTwice();
-    void askTwoOnce();
-    void askTwoTwice();
 };
 
 #endif


### PR DESCRIPTION
Feed in additional model-list base entries to xml export api using QMap. The 'DEVICE' tag and it's value should now be passed to this xml export function.