### PR TITLE
Revert "CMake increase min version to fix warning on recent Fedora"

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.1)
 
 project(zera-scpi LANGUAGES CXX)
 


### PR DESCRIPTION
It caused unforseeable results in zera-classes

This reverts commit 7e15d646264d286ca4cb1772d6f399b0e3015c6e.